### PR TITLE
Add 'No items' text and support 'wrapper style'

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,20 @@ addTestScene(<MySceneComponent items={[]}/>, 'Empty');
 addTestScene(<MySceneComponent items={['more','test','data']}/>, 'Three items');
 ```
 
+# Making space for header and footer bars
+
+In real app, your screens will normally have a header (and perhaps a footer). This means your actual component has a smaller space to render in.
+
+To support this there's a third optional argument to `addTestScene` called `wrapperStyle`. This is a standard React Native View style.
+Use the `padding` properties to adjust the rendering inset to your scene. You may want to store the style somewhere central in your app so
+you don't have to type it out each time you use `addTestScene`. 
+
+Example:
+
+```js
+addTestScene(<MySceneComponent items={['more','test','data']}/>, 'Three items', {paddingTop: 44, backgroundColor: 'black'});
+```
+ 
 ## Usage with Redux
 
 If you're using the `react-redux` `connect` method, make sure you pass the 'unconnected' version of the component to `addTestScene`, e.g.:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-component-viewer",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A searchable list of components or scenes in your app. Handy for tweaking layout or design without using the app",
   "main": "index.js",
   "scripts": {},

--- a/src/DebugSceneList.js
+++ b/src/DebugSceneList.js
@@ -47,11 +47,18 @@ class DebugSceneList extends Component {
       all: allScenes,
       modalVisible: false,
       selectedComponent: undefined,
+      selectedComponentWrapperStyle: undefined,
     };
 
-    this.onHideScene = () => this.setState({modalVisible: false, selectedComponent: undefined});
+    this.onHideScene = () =>
+      this.setState({modalVisible: false, selectedComponent: undefined, selectedComponentWrapperStyle: undefined});
 
-    this.onPressRow = data => this.setState({modalVisible: true, selectedComponent: data.component});
+    this.onPressRow = data =>
+      this.setState({
+        modalVisible: true,
+        selectedComponent: data.component,
+        selectedComponentWrapperStyle: data.wrapperStyle,
+      });
   }
 
   render() {
@@ -60,7 +67,7 @@ class DebugSceneList extends Component {
         <SearchableList onClose={this.props.onClose} onPressRow={this.onPressRow} items={this.state.all} />
         {this.state.modalVisible
           ? [
-              <View key={'modal1'} style={styles.selectedComponentWrapper}>
+              <View key={'modal1'} style={[styles.selectedComponentWrapper, this.state.selectedComponentWrapperStyle]}>
                 {this.state.selectedComponent}
               </View>,
               <TouchableHighlight key={'modal2'} style={styles.closeButton} onPress={this.onHideScene}>

--- a/src/SearchableList.js
+++ b/src/SearchableList.js
@@ -8,6 +8,7 @@ import {colors} from './theme';
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    backgroundColor: colors.whiteColor,
   },
   sceneRow: {borderBottomColor: colors.blackColor, borderBottomWidth: 1, height: 80, justifyContent: 'center'},
   sceneRowTitle: {alignSelf: 'center', fontSize: 20},
@@ -17,6 +18,8 @@ const styles = StyleSheet.create({
     backgroundColor: colors.lightGrayColor,
     padding: 5,
     flexDirection: 'row',
+    borderBottomWidth: 1,
+    borderBottomColor: colors.grayColor,
   },
   searchInput: {
     flex: 1,
@@ -29,11 +32,18 @@ const styles = StyleSheet.create({
     minHeight: 40,
   },
   doneButton: {
-    padding: 10,
+    padding: 6,
+    borderRadius: 5,
+    margin: 4,
   },
   doneButtonText: {
     color: colors.blackColor,
     fontWeight: 'bold',
+  },
+  noItemsText: {
+    alignSelf: 'center',
+    fontSize: 20,
+    marginTop: 20,
   },
 });
 
@@ -87,6 +97,7 @@ class SearchableList extends Component {
       <View style={styles.container}>
         <View key={'searchWrapper'} style={styles.searchWrapper}>
           <TextInput
+            underlineColorAndroid={'transparent'}
             autoCapitalize={'none'}
             autoCorrect={false}
             enablesReturnKeyAutomatically={true}
@@ -94,11 +105,19 @@ class SearchableList extends Component {
             onChangeText={this.search}
             clearButtonMode={'while-editing'}
           />
-          <TouchableHighlight underlayColor={'gray'} onPress={this.props.onClose} style={styles.doneButton}>
+          <TouchableHighlight underlayColor={colors.whiteColor} onPress={this.props.onClose} style={styles.doneButton}>
             <Text style={styles.doneButtonText}>Done</Text>
           </TouchableHighlight>
         </View>
-        <ListView key={'list'} style={{flex: 1}} dataSource={this.state.ds} renderRow={this.renderRow} />
+        {this.state.ds.getRowCount()
+          ? <ListView
+              enableEmptySections
+              key={'list'}
+              style={{flex: 1}}
+              dataSource={this.state.ds}
+              renderRow={this.renderRow}
+            />
+          : <Text style={styles.noItemsText}>No items</Text>}
       </View>
     );
   }

--- a/src/TestRegistry.js
+++ b/src/TestRegistry.js
@@ -18,7 +18,7 @@ const registeredScenes: {|[string]: RegisteredSceneType|} = {};
  *
  * component - output of a render e.g. <MyComponent param={value}/>.
  */
-function addTestScene(component: React$Element, title: ?string) {
+function addTestScene(component: React$Element, title: ?string, wrapperStyle: ?Object = {}) {
   if (!component || !component.type) {
     return;
   }
@@ -30,7 +30,7 @@ function addTestScene(component: React$Element, title: ?string) {
     console.log(`Scene already registered with title=${key}. Overwriting..`);
   }
 
-  registeredScenes[key] = {name: componentName, component, title};
+  registeredScenes[key] = {name: componentName, component, title, wrapperStyle};
 }
 
 /**


### PR DESCRIPTION
- Display 'no items' where there are no results (or no items registered)	
- Support providing optional style to wrap the displayed component. Useful for simulating header and footer bars

