### PR TITLE
Names in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,29 +72,37 @@ class MySceneComponent extends React.Component {
 addTestScene(<MySceneComponent
   myProp1={'test data'}
   myProp2={['more','test','data']}
-/>);
+/>,
+{name: 'MySceneComponent'},
+);
 ```
 
-You can add the same component several times with different data. To do this, add a description as the second parameter to `addTestScene`:
+You can add the same component several times with different data. To do this, add a `title` property to the the second parameter to `addTestScene`:
 
 ```js
-addSceneTest(<MySceneComponent items={[]}/>, 'Empty');
+addSceneTest(<MySceneComponent items={[]}/>, {name: 'MySceneComponent', title: 'Empty'});
 
-addSceneTest(<MySceneComponent items={['more','test','data']}/>, 'Three items');
+addSceneTest(<MySceneComponent items={['more','test','data']}/>, {name: 'MySceneComponent', title: 'Three items'});
 ```
 
 ## Making space for header and footer bars
 
 In real app, your screens will normally have a header (and perhaps a footer). This means your actual component has a smaller space to render in.
 
-To support this there's a third optional argument to `addTestScene` called `wrapperStyle`. This is a standard React Native View style.
+To support this there's an optional property `wrapperStyle` on the second parameter to `addSceneTest`. This is a standard React Native View style.
+
 Use the `padding` properties to adjust the rendering inset to your scene. You may want to store the style somewhere central in your app so
 you don't have to type it out each time you use `addTestScene`. 
 
 Example:
 
 ```js
-addSceneTest(<MySceneComponent items={['more','test','data']}/>, 'Three items', {paddingTop: 44, backgroundColor: 'black'});
+addSceneTest(<MySceneComponent items={['more','test','data']}/>, 
+{ 
+  name: 'MySceneComponent',
+  title: Three items', 
+  wrapperStyle: {paddingTop: 44, backgroundColor: 'black'}),
+}
 ```
 
 # Registering Test Components
@@ -116,8 +124,11 @@ import {addComponentTest} from 'react-native-component-viewer'; // <-- Add this 
 const wrapperStyle = {width: 200}; // style of container holding the component - useful for constraining to different sizes
 addComponentTest(
       <Button type={'large'} title={'Button title'} />,
-      `Large Button`, // Title
-      wrapperStyle,
+      {
+       name: 'Button',
+       title: 'Large button',
+	    wrapperStyle,
+	   }
     )
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-component-viewer",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "A searchable list of components or scenes in your app. Handy for tweaking layout or design without using the app",
   "main": "index.js",
   "scripts": {},

--- a/src/TestRegistry.js
+++ b/src/TestRegistry.js
@@ -39,8 +39,8 @@ function getName(component: React$Element) {
  * The class name of the component is automatically extracted from the component.
  *
  * @param component - output of a render e.g. <MyComponent param={value}/>.
- * @param title - subtitle for the test e.g. 'with long name'
  * @param type - For Screens/Scenes that should be displayed full-screen, use type='scene'. To display the same component in different states on the same screen, use type='component'.
+ * @param options - for the test
  */
 function addTest(component: React$Element, type: 'scene' | 'component', options: TestType = {}) {
   if (!component || !component.type) {
@@ -105,27 +105,36 @@ function getTests(): Array<RegisteredItemType> {
 }
 
 /**
- * Add test for a scene
+ * Add test for a scene. Will be displayed full-screen in the test UI
+ *
+ * @param component - JSX of component to test
+ * @param options - TestType instance with options for the test. Backwards-compatible with previous version.
+ * @param wrapperStyle - don't use this. Instead use the `wrapperStyle` property on `options`
  */
-const addSceneTest = (component: React$Element, titleOrOptions: ?string | ?TestType, wrapperStyle: ?Object = {}) => {
-  if (R.is(Object, titleOrOptions)) {
-    return addTest(component, 'scene', titleOrOptions);
+const addSceneTest = (component: React$Element, options: ?string | ?TestType, wrapperStyle: ?Object = {}) => {
+  if (R.is(Object, options)) {
+    return addTest(component, 'scene', options);
   }
-  addTest(component, 'scene', {title: titleOrOptions, wrapperStyle});
+  // Backwards compatibility, where options is actually a string
+  addTest(component, 'scene', {title: options, wrapperStyle});
 };
 
 /**
- * Add test for a component
+ * Add test for a component. Will be displayed in a ScrollView along with other tests for this component.
+ *
+ * @param component - JSX of component to test
+ * @param options - TestType instance with options for the test. Backwards-compatible with previous version.
+ * @param wrapperStyle - don't use this. Instead use the `wrapperStyle` property on `options`
  */
 const addComponentTest = (
   component: React$Element,
-  titleOrOptions: ?string | ?TestType,
+  options: ?string | ?TestType,
   wrapperStyle: ?Object = {}
 ) => {
-  if (R.is(Object, titleOrOptions)) {
-    return addTest(component, 'component', titleOrOptions);
+  if (R.is(Object, options)) {
+    return addTest(component, 'component', options);
   }
-  addTest(component, 'component', {title: titleOrOptions, wrapperStyle});
+  addTest(component, 'component', {title: options, wrapperStyle});
 };
 
 /**

--- a/src/TestRegistry.js
+++ b/src/TestRegistry.js
@@ -55,43 +55,43 @@ function addTest(component: React$Element, type: 'scene' | 'component', options:
   switch (type) {
     // For each component, we store an array of different 'views' onto the component
     case 'component':
-    {
-      const key = name;
+      {
+        const key = name;
 
-      let existing: ?RegisteredItemType = registeredItems[key];
+        let existing: ?RegisteredItemType = registeredItems[key];
 
-      if (existing) {
-        if (!existing.states) {
-          console.log(`Probably trying to register a component on something previously registered as a scene`);
-          return;
+        if (existing) {
+          if (!existing.states) {
+            console.log(`Probably trying to register a component on something previously registered as a scene`);
+            return;
+          }
+          existing.states = R.uniqBy(i => i.title, [...existing.states, itemDetails]); // remove dupes, based on title
+        } else {
+          // Register as empty placeholder so it can be rendered easily in the list
+          existing = {
+            component: null,
+            wrapperStyle: null,
+            type: 'component',
+            states: [itemDetails],
+            title,
+            name,
+          };
         }
-        existing.states = R.uniqBy(i => i.title, [...existing.states, itemDetails]); // remove dupes, based on title
-      } else {
-        // Register as empty placeholder so it can be rendered easily in the list
-        existing = {
-          component: null,
-          wrapperStyle: null,
-          type: 'component',
-          states: [itemDetails],
-          title,
-          name,
-        };
-      }
 
-      registeredItems[key] = existing;
-      // title is state1, state2, state3
-      existing.title = `${existing.states.length} test${existing.states.length !== 1 ? 's' : ''}`;
-    }
+        registeredItems[key] = existing;
+        // title is state1, state2, state3
+        existing.title = `${existing.states.length} test${existing.states.length !== 1 ? 's' : ''}`;
+      }
       break;
     // For scenes, we have a single item
     case 'scene':
-    {
-      const key = title || name;
-      if (registeredItems[key]) {
-        console.log(`Scene already registered with title=${key}. Overwriting..`);
+      {
+        const key = title || name;
+        if (registeredItems[key]) {
+          console.log(`Scene already registered with title=${key}. Overwriting..`);
+        }
+        registeredItems[key] = itemDetails;
       }
-      registeredItems[key] = itemDetails;
-    }
       break;
     default:
   }
@@ -126,11 +126,7 @@ const addSceneTest = (component: React$Element, options: ?string | ?TestType, wr
  * @param options - TestType instance with options for the test. Backwards-compatible with previous version.
  * @param wrapperStyle - don't use this. Instead use the `wrapperStyle` property on `options`
  */
-const addComponentTest = (
-  component: React$Element,
-  options: ?string | ?TestType,
-  wrapperStyle: ?Object = {}
-) => {
+const addComponentTest = (component: React$Element, options: ?string | ?TestType, wrapperStyle: ?Object = {}) => {
   if (R.is(Object, options)) {
     return addTest(component, 'component', options);
   }

--- a/src/TestRegistry.js
+++ b/src/TestRegistry.js
@@ -5,14 +5,34 @@ import * as R from 'ramda';
  * Type of values in registeredScenes
  */
 export type RegisteredItemType = {|
-  name: string, // extracted from the component's name
+  name: string, // extracted from the component's name, or provided by user
   title: ?string, // title used when scene is used several times with different test data
   component: React$Element, // the actual element itself
   type: 'scene' | 'component',
   states?: Array<RegisteredItemType>,
 |};
 
+/**
+ * Parameter for the exported methods
+ */
+export type TestType = {
+  name: string,
+  title?: string,
+  wrapperStyle: ?Object,
+};
+
 const registeredItems: {|[string]: RegisteredItemType|} = {};
+
+/**
+ * Get the name of the component. Note only works in debug builds as production builds minify JS code and remove names
+ * Stateless components have .name, classes have .displayName.
+ */
+function getName(component: React$Element) {
+  if (!component) {
+    return '(no component)';
+  }
+  return component.type.displayName || component.type.name;
+}
 
 /**
  * Register a test item. Title is optional.
@@ -22,61 +42,56 @@ const registeredItems: {|[string]: RegisteredItemType|} = {};
  * @param title - subtitle for the test e.g. 'with long name'
  * @param type - For Screens/Scenes that should be displayed full-screen, use type='scene'. To display the same component in different states on the same screen, use type='component'.
  */
-function addTest(
-  component: React$Element,
-  title: ?string,
-  wrapperStyle: ?Object = {},
-  type: 'scene' | 'component' = 'scene'
-) {
+function addTest(component: React$Element, type: 'scene' | 'component', options: TestType = {}) {
   if (!component || !component.type) {
     return;
   }
-  // Get the name of the component.
-  // Stateless components have .name, classes have .displayName.
-  const componentName = component.type.displayName || component.type.name;
+  // Use provided name, or extract from component if not given
+  const name = options.name || getName(component);
+  const title = options.title;
 
-  const itemDetails = {name: componentName, component, title, wrapperStyle, type};
+  const itemDetails = {...options, component, type, name};
 
   switch (type) {
     // For each component, we store an array of different 'views' onto the component
     case 'component':
-      {
-        const key = componentName;
+    {
+      const key = name;
 
-        let existing: ?RegisteredItemType = registeredItems[key];
+      let existing: ?RegisteredItemType = registeredItems[key];
 
-        if (existing) {
-          if (!existing.states) {
-            console.log(`Probably trying to register a component on something previously registered as a scene`);
-            return;
-          }
-          existing.states = R.uniqBy(i => i.title, [...existing.states, itemDetails]); // remove dupes, based on title
-        } else {
-          // Register as empty placeholder so it can be rendered easily in the list
-          existing = {
-            component: null,
-            wrapperStyle: null,
-            name: componentName,
-            title: title,
-            type: 'component',
-            states: [itemDetails],
-          };
+      if (existing) {
+        if (!existing.states) {
+          console.log(`Probably trying to register a component on something previously registered as a scene`);
+          return;
         }
-
-        registeredItems[key] = existing;
-        // title is state1, state2, state3
-        existing.title = `${existing.states.length} test${existing.states.length !== 1 ? 's' : ''}`;
+        existing.states = R.uniqBy(i => i.title, [...existing.states, itemDetails]); // remove dupes, based on title
+      } else {
+        // Register as empty placeholder so it can be rendered easily in the list
+        existing = {
+          component: null,
+          wrapperStyle: null,
+          type: 'component',
+          states: [itemDetails],
+          title,
+          name,
+        };
       }
+
+      registeredItems[key] = existing;
+      // title is state1, state2, state3
+      existing.title = `${existing.states.length} test${existing.states.length !== 1 ? 's' : ''}`;
+    }
       break;
     // For scenes, we have a single item
     case 'scene':
-      {
-        const key = title || componentName;
-        if (registeredItems[key]) {
-          console.log(`Scene already registered with title=${key}. Overwriting..`);
-        }
-        registeredItems[key] = itemDetails;
+    {
+      const key = title || name;
+      if (registeredItems[key]) {
+        console.log(`Scene already registered with title=${key}. Overwriting..`);
       }
+      registeredItems[key] = itemDetails;
+    }
       break;
     default:
   }
@@ -92,14 +107,26 @@ function getTests(): Array<RegisteredItemType> {
 /**
  * Add test for a scene
  */
-const addSceneTest = (component: React$Element, title: ?string, wrapperStyle: ?Object = {}) =>
-  addTest(component, title, wrapperStyle, 'scene');
+const addSceneTest = (component: React$Element, titleOrOptions: ?string | ?TestType, wrapperStyle: ?Object = {}) => {
+  if (R.is(Object, titleOrOptions)) {
+    return addTest(component, 'scene', titleOrOptions);
+  }
+  addTest(component, 'scene', {title: titleOrOptions, wrapperStyle});
+};
 
 /**
  * Add test for a component
  */
-const addComponentTest = (component: React$Element, title: ?string, wrapperStyle: ?Object = {}) =>
-  addTest(component, title, wrapperStyle, 'component');
+const addComponentTest = (
+  component: React$Element,
+  titleOrOptions: ?string | ?TestType,
+  wrapperStyle: ?Object = {}
+) => {
+  if (R.is(Object, titleOrOptions)) {
+    return addTest(component, 'component', titleOrOptions);
+  }
+  addTest(component, 'component', {title: titleOrOptions, wrapperStyle});
+};
 
 /**
  * @deprecated - use addSceneTest


### PR DESCRIPTION
See #4 - Minification removes run-time names of components, so items were appearing in list mostly called `t` in production mode.

This change refactors the API so you can provide a `name` property via a new options parameter.
It's backwards compatible, so your previous code will still work. If `name` is not provided, system extracts the name from the component as before.