### PR TITLE
Remove lateral padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ addSceneTest(<MySceneComponent items={['more','test','data']}/>,
 
 # Registering Test Components
 
-When testing acomponent such as a Button, you'll most likely want to view all the possible states of the button on a single screen
+When testing a component such as a Button, you'll most likely want to view all the possible states of the button on a single screen
 
 For example:
 
@@ -149,7 +149,7 @@ export default connect(
 	}),
 	dispatch => ({
 		//.. mapDispatchToProps
-	})(MyComponent);
+	}))(MyComponent);
 	
 // we export the connected component, but pass the
 // unconnected component to addTestScene

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-component-viewer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A searchable list of components or scenes in your app. Handy for tweaking layout or design without using the app",
   "main": "index.js",
   "scripts": {},

--- a/src/DebugSceneList.js
+++ b/src/DebugSceneList.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 
 import {View, StyleSheet, Text, TouchableHighlight, Alert, ScrollView} from 'react-native';
-import {getTests} from './TestRegistry';
+import {getTests, TestType} from './TestRegistry';
 import type {RegisteredItemType} from './TestRegistry';
 import SearchableList from './SearchableList';
 
@@ -23,7 +23,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   componentWrapper: {
-    marginHorizontal: 20,
     alignSelf: 'stretch',
   },
   componentTitle: {
@@ -90,8 +89,8 @@ class DebugSceneList extends Component {
             return [
               <Text key={`${i.name}_${i.title}_title`} style={styles.componentTitle}>{i.title}</Text>,
               <View key={`${i.name}_${i.title}_component`} style={[styles.componentWrapper, i.wrapperStyle]}>
-              {i.component}
-            </View>]
+                {i.component}
+              </View>];
           })}
         </ScrollView>
       </View>

--- a/src/DebugSceneList.js
+++ b/src/DebugSceneList.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 
 import {View, StyleSheet, Text, TouchableHighlight, Alert, ScrollView} from 'react-native';
-import {getTests, TestType} from './TestRegistry';
+import {getTests} from './TestRegistry';
 import type {RegisteredItemType} from './TestRegistry';
 import SearchableList from './SearchableList';
 

--- a/src/TestRegistry.js
+++ b/src/TestRegistry.js
@@ -10,6 +10,7 @@ export type RegisteredItemType = {|
   component: React$Element, // the actual element itself
   type: 'scene' | 'component',
   states?: Array<RegisteredItemType>,
+  wrapperStyle: ?Object,
 |};
 
 /**


### PR DESCRIPTION
Fixes #10:
- Remove horizontal margins, still can be configured via `wrapperStyle: {marginHorizontal: 20}` as part of the options in `addTest`
- Add wrapperStyle to `RegisteredItemType`, so there are no warnings on IDE when accessing the property
- Patch version bump, to be ready to npm publish
- Readme typo fixes