### PR TITLE
Accept unrendered components too, and pass them a `closeThisTest` prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-component-viewer",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A searchable list of components or scenes in your app. Handy for tweaking layout or design without using the app",
   "main": "index.js",
   "scripts": {},

--- a/src/DebugSceneList.js
+++ b/src/DebugSceneList.js
@@ -22,6 +22,9 @@ const styles = StyleSheet.create({
   componentModalScrollView: {
     alignItems: 'center',
   },
+  componentModalSpacer: {
+    height: 30,
+  },
   componentWrapper: {
     alignSelf: 'stretch',
   },
@@ -119,13 +122,25 @@ class DebugSceneList extends Component {
     removeUpdateListener(this.handleTestsUpdated);
   }
 
+  renderWithProps(Component) {
+    // If we're passed a rendered component, use it as-is.
+    if (!(Component instanceof Function)) {
+      return Component;
+    }
+    // If we're passed an unrendered component, render it.
+    // This list of props might grow in future.
+    return (
+      <Component closeThisTest={this.onHideScene} />
+    );
+  }
+
   renderSceneModal() {
     return (
       <View
         key={'component-viewer-modal'}
         style={[styles.selectedComponentWrapper, this.state.selectedItem && this.state.selectedItem.wrapperStyle]}
       >
-        {this.state.selectedItem.component}
+        {this.renderWithProps(this.state.selectedItem.component)}
       </View>
     );
   }
@@ -141,9 +156,10 @@ class DebugSceneList extends Component {
           {selectedItem.states.map((i: RegisteredItemType) => [
             <Text key={`${i.name}_${i.title}_title`} style={styles.componentTitle}>{i.title}</Text>,
             <View key={`${i.name}_${i.title}_component`} style={[styles.componentWrapper, i.wrapperStyle]}>
-              {i.component}
+              {this.renderWithProps(i.component)}
             </View>,
           ])}
+          <View style={styles.componentModalSpacer} />
         </ScrollView>
       </View>
     );

--- a/src/TestRegistry.js
+++ b/src/TestRegistry.js
@@ -47,7 +47,7 @@ function getName(component: React.Element<any>) {
  * @param options - for the test
  */
 function addTest(component: React.Element<any>, type: 'scene' | 'component', options: TestType = {}) {
-  if (!component || !component.type) {
+  if (!component || (!component.type && !component instanceof Function)) {
     return;
   }
   // Use provided name, or extract from component if not given


### PR DESCRIPTION
It occurs to me that, 99% of the time, when I'm testing a modal, the modal *itself* has a perfectly good close button, even though the component viewer's own close has been made inaccessible by the modal component, so here's a PR that to make it possible to use the modal's own close button to work around #14.

Also some of my component tests wind up with built-in the 'Close' button covering important stuff, so I slapped a few pixels of vertical space on the component viewer.