### PR TITLE
Add vertical space around the components scene

### DIFF
--- a/src/DebugSceneList.js
+++ b/src/DebugSceneList.js
@@ -20,7 +20,9 @@ const styles = StyleSheet.create({
     backgroundColor: colors.lightGrayColor,
   },
   componentModalScrollView: {
+    marginTop: 20,
     alignItems: 'center',
+    marginBottom: 400,
   },
   componentWrapper: {
     alignSelf: 'stretch',


### PR DESCRIPTION
Some of my component tests wind up with built-in the 'Close' button covering important stuff, so this commit slaps a few hundred pixels of vertical space on the components scene.