### PR TITLE
Fix PropTypes import (and bump version).

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Especially useful for accessing screens that are hard to get to, or for testing 
 
 ![animated gif](docs/Demo.gif)
 
+Requires react-native >= 0.43.0. For older versions of RN, please use version 0.4.0 or below.
+
 # Installation
 
 This is a pure JavaScript library, so there's no need to run `react-native link` or manually add any frameworks or libraries.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-component-viewer",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A searchable list of components or scenes in your app. Handy for tweaking layout or design without using the app",
   "main": "index.js",
   "scripts": {},

--- a/src/DebugSceneList.js
+++ b/src/DebugSceneList.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 
 import {View, StyleSheet, Text, TouchableHighlight, ScrollView, AsyncStorage} from 'react-native';
 import {getTests, getTest, addUpdateListener, removeUpdateListener} from './TestRegistry';

--- a/src/SearchableList.js
+++ b/src/SearchableList.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 
 import {View, StyleSheet, Text, ListView, TextInput, TouchableHighlight, Platform} from 'react-native';
 


### PR DESCRIPTION
React Native 0.49.0 now requires that PropTypes be imported from `prop-types` instead of from `React.PropTypes`, so this fixes imports to comply that.