### PR TITLE
Use Collapse Group if possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-component-viewer",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A searchable list of components or scenes in your app. Handy for tweaking layout or design without using the app",
   "main": "index.js",
   "scripts": {},

--- a/src/TestRegistry.js
+++ b/src/TestRegistry.js
@@ -119,12 +119,17 @@ function notifyListeners(key: string) {
     clearTimeout(listenerDebounceId);
     listenerDebounceId = null;
 
-    console.log(`.. notifying react-native-component-viewer test updated.. ${JSON.stringify(list)}`);
+    if (console.groupCollapsed) { // Check if groupCollapsed is available
+      console.groupCollapsed();
+      list.forEach(item => console.log(JSON.stringify(item)));
+      console.groupEnd();
+    } else {
+      console.log(`.. notifying react-native-component-viewer test updated.. ${JSON.stringify(list)}`);
+    }
     R.forEach(r => {
       try {
         r(list);
-      } catch (ignored) {
-      }
+      } catch (ignored) {}
     }, registeredListeners);
   }, 250);
 }
@@ -188,7 +193,7 @@ const addComponentTest = (component: React.Element<any>, options: ?string | ?Tes
   addTest(component, 'component', {title: options, wrapperStyle});
 };
 
-function addUpdateListener(listener: Array<TestType> => void) {
+function addUpdateListener(listener: (Array<TestType>) => void) {
   const index = registeredListeners.indexOf(listener);
   if (index === -1) {
     registeredListeners.push(listener);
@@ -197,7 +202,7 @@ function addUpdateListener(listener: Array<TestType> => void) {
   }
 }
 
-function removeUpdateListener(listener: Array<TestType> => void) {
+function removeUpdateListener(listener: (Array<TestType>) => void) {
   const index = registeredListeners.indexOf(listener);
   if (index !== -1) {
     registeredListeners.splice(index, 1);


### PR DESCRIPTION
- Bump versions patch
- Print list of components as a collapsed group if it is available.

Tested on simulator with and without Chrome attached:

With Chrome attached (use collapse group):
![screen shot 2018-01-30 at 13 01 27](https://user-images.githubusercontent.com/4411878/35567948-cb714a70-05be-11e8-8fbf-a1b4f8a18d47.png)
![screen shot 2018-01-30 at 13 01 37](https://user-images.githubusercontent.com/4411878/35567952-d0e6ad7e-05be-11e8-8dd3-63d64ed5b326.png)

Without Chrome attached (does not use collapse group):
![screen shot 2018-01-30 at 13 02 31](https://user-images.githubusercontent.com/4411878/35567964-df2b31fc-05be-11e8-8776-c0430d700bc4.png)

Fix #22