### PR TITLE
Dropped RN AsyncStorage in favour of the Community version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ npm i -S react-native-component-viewer
 
 - You may need to close and restart the React Native packager.
 
+# Dependencies
+
+This will require you to add the `Community AsyncStorage` to your project dependencies.
+
+```
+npm i -S @react-native-community/async-storage
+```
+
 # Usage
 
 This library does not assume any specific navigation library is in use. As a result it can be configured for us with [react-navigation](https://github.com/react-community/react-navigation), [react-native-router-flux](https://github.com/aksonov/react-native-router-flux), and others.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This will require you to add the `Community AsyncStorage` to your project depend
 npm i -S @react-native-community/async-storage
 ```
 
+And follow the instructions for <a href="https://github.com/react-native-community/react-native-async-storage/blob/master/docs/Linking.md"> manual linking </a>
+
 # Usage
 
 This library does not assume any specific navigation library is in use. As a result it can be configured for us with [react-navigation](https://github.com/react-community/react-navigation), [react-native-router-flux](https://github.com/aksonov/react-native-router-flux), and others.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-component-viewer",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "A searchable list of components or scenes in your app. Handy for tweaking layout or design without using the app",
   "main": "index.js",
   "scripts": {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-component-viewer",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A searchable list of components or scenes in your app. Handy for tweaking layout or design without using the app",
   "main": "index.js",
   "scripts": {},
@@ -27,7 +27,8 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "@react-native-community/async-storage": "*"
   },
   "devDependencies": {
     "eslint-config-calvium": "^0.3.0"

--- a/src/DebugSceneList.js
+++ b/src/DebugSceneList.js
@@ -1,7 +1,8 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
-import {View, StyleSheet, Text, TouchableHighlight, ScrollView, AsyncStorage} from 'react-native';
+import {View, StyleSheet, Text, TouchableHighlight, ScrollView} from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 import {getTests, getTest, addUpdateListener, removeUpdateListener} from './TestRegistry';
 import type {RegisteredItemType} from './TestRegistry';
 import SearchableList from './SearchableList';


### PR DESCRIPTION
Fix #28

- Replaced react-native AsyncStorage with react-native-community AsyncStorage
- Updated README file 

Test: 
- Test the branch in a project that uses @react-native-community/async-storage 
- Open the component viewer and check that warnings related to AsyncStorage don't show up